### PR TITLE
Add custom driver to delegate and expose validation

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.h
+++ b/Sparkle/SUBasicUpdateDriver.h
@@ -15,7 +15,7 @@
 #import "SUAppcast.h"
 
 @class SUAppcastItem, SUHost;
-@interface SUBasicUpdateDriver : SUUpdateDriver <NSURLDownloadDelegate, SUUnarchiverDelegate>
+SU_EXPORT @interface SUBasicUpdateDriver : SUUpdateDriver <NSURLDownloadDelegate, SUUnarchiverDelegate>
 
 @property (strong, readonly) SUAppcastItem *updateItem;
 @property (strong, readonly) NSURLDownload *download;
@@ -40,6 +40,7 @@
 - (void)unarchiverDidFinish:(SUUnarchiver *)ua;
 - (void)unarchiverDidFail:(SUUnarchiver *)ua;
 - (void)failedToApplyDeltaUpdate;
+- (BOOL)validateUpdateDownloaded;
 
 - (void)installWithToolAndRelaunch:(BOOL)relaunch;
 - (void)installWithToolAndRelaunch:(BOOL)relaunch displayingUserInterface:(BOOL)showUI;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -373,6 +373,11 @@
     [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{ NSLocalizedDescriptionKey: SULocalizedString(@"An error occurred while extracting the archive. Please try again later.", nil) }]];
 }
 
+- (BOOL)validateUpdateDownloaded
+{
+    return [self validateUpdateDownloadedToPath:self.downloadPath extractedToPath:self.tempDir DSASignature:self.updateItem.DSASignature publicDSAKey:self.host.publicDSAKey];
+}
+
 - (void)installWithToolAndRelaunch:(BOOL)relaunch
 {
     // Perhaps a poor assumption but: if we're not relaunching, we assume we shouldn't be showing any UI either. Because non-relaunching installations are kicked off without any user interaction, we shouldn't be interrupting them.

--- a/Sparkle/SUUIBasedUpdateDriver.h
+++ b/Sparkle/SUUIBasedUpdateDriver.h
@@ -15,7 +15,7 @@
 
 @class SUStatusController;
 
-@interface SUUIBasedUpdateDriver : SUBasicUpdateDriver <SUUnarchiverDelegate>
+SU_EXPORT @interface SUUIBasedUpdateDriver : SUBasicUpdateDriver <SUUnarchiverDelegate>
 
 - (void)showModalAlert:(NSAlert *)alert;
 - (IBAction)cancelDownload:(id)sender;

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -134,6 +134,15 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
 @protocol SUUpdaterDelegate <NSObject>
 @optional
 
+
+/*!
+ Returns a custom driver.
+
+
+ \param updater The SUUpdater instance.
+ */
+- (SUUpdateDriver*)driverForUpdater:(SUUpdater *)updater;
+
 /*!
     Returns whether to allow Sparkle to pop up.
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -303,7 +303,16 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     // Background update checks should only happen if we have a network connection.
     //	Wouldn't want to annoy users on dial-up by establishing a connection every
     //	hour or so:
-    SUUpdateDriver *theUpdateDriver = [[([self automaticallyDownloadsUpdates] ? [SUAutomaticUpdateDriver class] : [SUScheduledUpdateDriver class])alloc] initWithUpdater:self];
+    SUUpdateDriver *theUpdateDriver = nil;
+    if ([self.delegate respondsToSelector:@selector(driverForUpdater:)])
+    {
+        theUpdateDriver = [self.delegate driverForUpdater:self];
+    }
+
+    if (theUpdateDriver == nil)
+    {
+        theUpdateDriver = [[([self automaticallyDownloadsUpdates] ? [SUAutomaticUpdateDriver class] : [SUScheduledUpdateDriver class])alloc] initWithUpdater:self];
+    }
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		[self checkForUpdatesInBgReachabilityCheckWithDriver:theUpdateDriver];


### PR DESCRIPTION
Sparkle has a nice driver functionality to customize update
machinisms, but it is not exposed. The usage of those
drivers is mostly hard wired. Added the possibility
to supply a custom driver.

I was able to implement most of what we need with
public interfaces, but I had to expose validation
on SUBasicUpdateDriver.
